### PR TITLE
Remove some quotes and the word "object"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 __pycache__
+/.idea

--- a/spectools/templates/json_object_detail.html
+++ b/spectools/templates/json_object_detail.html
@@ -33,7 +33,7 @@
 
 {% for rel in child_relationships %}
 <tr>
-    <td><nobr><b>"{{ rel.child_key }}"</b></nobr></td>
+    <td><nobr><b>{{ rel.child_key }}</b></nobr></td>
     <td>
         {% if rel.child.is_array %}
             An array of
@@ -44,10 +44,10 @@
             The string <code>"{{ rel.child.description }}"</code>
         {% elif rel.child.is_user_defined_dict %}
             {% with rel.child.get_child_relationships.0 as childrel %}
-            An object with user-defined keys, where each value is a <a href="{% relative_url_string childrel.child.get_absolute_url %}">{{ childrel.child.name }} object</a>
+            An object with user-defined keys, where each value is a <a href="{% relative_url_string childrel.child.get_absolute_url %}">{{ childrel.child.name }}</a>
             {% endwith %}
         {% else %}
-        <a href="{% relative_url_string rel.child.get_absolute_url %}">{{ rel.child.name }} object</a>
+        <a href="{% relative_url_string rel.child.get_absolute_url %}">{{ rel.child.name }}</a>
         {% endif %}
     </td>
     <td>{{ rel.is_required|yesno|title }}</td>


### PR DESCRIPTION
Remove some "object" descriptions in docs where it is obvious ("boolean object" -> boolean)

Remove quotes around key names -- most languages will address these keys as `event.staff` not `"event": {"staff"...}` and we're trying to discourage manual writing of JSON anyhow