### PR TITLE
Patch fix Windows CRLF in doc generation

### DIFF
--- a/spectools/management/commands/makesite.py
+++ b/spectools/management/commands/makesite.py
@@ -65,15 +65,16 @@ class SiteGenerator:
         self.generate_url(url)
 
     def generate_url(self, url):
-        html = self.client.get(url).content
+        html = self.client.get(url).content.decode('utf-8')
+        html = html.replace('\r', '')
         file_dir = os.path.join(self.dirname, url[1:])
         self.log(file_dir)
         if url.endswith('/'):
             os.makedirs(file_dir, exist_ok=True)
-            with open(os.path.join(file_dir, INDEX_FILE), 'wb') as fp:
+            with open(os.path.join(file_dir, INDEX_FILE), 'w') as fp:
                 fp.write(html)
         else:
-            with open(file_dir, 'wb') as fp:
+            with open(file_dir, 'w') as fp:
                 fp.write(html)
 
     def copy_media_files(self):

--- a/spectools/management/commands/makesite.py
+++ b/spectools/management/commands/makesite.py
@@ -66,7 +66,10 @@ class SiteGenerator:
 
     def generate_url(self, url):
         html = self.client.get(url).content.decode('utf-8')
+
+        # Normalize Windows newlines ("\r\n") to Unix style ("\n").
         html = html.replace('\r', '')
+
         file_dir = os.path.join(self.dirname, url[1:])
         self.log(file_dir)
         if url.endswith('/'):


### PR DESCRIPTION
before this change:

```
% file ../docs/version-history/30/index.html

../docs/version-history/30/index.html: HTML document text, Unicode text, UTF-8 text, 
with very long lines (355), with CRLF, LF line terminators
```

After

```
% file ../docs/version-history/30/index.html
../docs/version-history/30/index.html: HTML document text, Unicode text, UTF-8 text, 
with very long lines (355)
```

Not sure where the Windows line feeds are creeping in -- all the .html files in the templates are fine in mnxdocgenerator.  But this at least fixes the problems we've been seeing, at least on the MusicXML side.