### PR TITLE
Replace 'Optional' with 'Zero or one times'

### DIFF
--- a/spectools/models.py
+++ b/spectools/models.py
@@ -274,7 +274,7 @@ class XMLElement(models.Model):
                 elif min_amount == 1 and max_amount is None:
                     return 'In this order (One or more times)'
                 elif min_amount == 0 and max_amount == 1:
-                    return 'In this order (Optional)'
+                    return 'In this order (Zero ot one times)'
         return {
             XMLElement.CHILDREN_TYPE_UNORDERED: 'In any order',
             XMLElement.CHILDREN_TYPE_SEQUENCE: 'In this order',


### PR DESCRIPTION
The latter is more precise than the former because it tells exactly how often something can occur, while the quantity of the former can only be deduced by exclusion, i.e., you have to see the other variants ('one or more times', 'zero or more times') to find out that only the meaning 'zero or one times' remains.